### PR TITLE
Add stock data and flexible ticker input

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai >=1.0.0
 pytesseract
 pillow
 requests
+yfinance


### PR DESCRIPTION
## Summary
- make ticker input empty so user can enter their own symbols
- filter news to last week and display article source and date
- show latest stock price and basic financials using `yfinance`
- add yfinance to requirements

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b055507708325837319c80ba1885c