### PR TITLE
Improve OCR portfolio summary table

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,26 +145,28 @@ with st.sidebar:
         except Exception as e:
             st.error(f"OCR failed: {e}")
 
-        total = 0.0
+    total = 0.0
     remove_keys = []
 
     if positions:
         st.markdown("### Portfolio Summary")
-        header = st.columns([2, 2, 2, 1])
+        header = st.columns([2, 2, 2, 2, 1])
         header[0].markdown("**Ticker**")
         header[1].markdown("**Shares**")
-        header[2].markdown("**Total**")
-        header[3].markdown(" ")
+        header[2].markdown("**Price**")
+        header[3].markdown("**Total**")
+        header[4].markdown(" ")
 
         for t, shares in positions.items():
             price, *_ = fetch_stock_info(t)
             value = price * shares if price else 0.0
             total += value
-            row = st.columns([2, 2, 2, 1])
+            row = st.columns([2, 2, 2, 2, 1])
             row[0].write(t)
             row[1].write(shares)
-            row[2].write(f"${value:,.2f}")
-            if row[3].button("Remove", key=f"remove_{t}"):
+            row[2].write(f"${price:,.2f}" if price else "N/A")
+            row[3].write(f"${value:,.2f}")
+            if row[4].button("Remove", key=f"remove_{t}"):
                 remove_keys.append(t)
 
         for rk in remove_keys:


### PR DESCRIPTION
## Summary
- fix `total` initialization outside of OCR block
- add column for price in portfolio summary
- adjust table layout for cleaner view

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b365575c88325a1e98af63fc2828c