### PR TITLE
Improve OCR portfolio summary table

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,14 +82,29 @@ def analyze_article(ticker, article):
         sentiment = "bad"
     return summary, sentiment
 
-def parse_positions(text):
-    """Parse lines like 'AAPL 10' and return dict of ticker -> shares."""
-    positions = {}
+def parse_positions(text: str) -> dict:
+    """Return a mapping of ticker -> shares from raw OCR text.
+
+    The OCR output can be noisy, so this parser looks for the first ticker
+    symbol (letters) and the first numeric value on each line. This makes it
+    tolerant of additional columns like price or total that may appear in the
+    screenshot table.
+    """
+
+    positions: dict[str, float] = {}
     for line in text.splitlines():
-        match = re.search(r"([A-Za-z]+)\s+(\d+(?:\.\d+)?)", line)
-        if match:
-            ticker, shares = match.groups()
-            positions[ticker.upper()] = positions.get(ticker.upper(), 0) + float(shares)
+        tokens = re.findall(r"[A-Za-z]+|[\d,.]+", line)
+        if len(tokens) < 2:
+            continue
+        ticker, shares_token = tokens[0], tokens[1]
+        if not ticker.isalpha():
+            continue
+        try:
+            shares = float(shares_token.replace(",", ""))
+        except ValueError:
+            continue
+        positions[ticker.upper()] = positions.get(ticker.upper(), 0.0) + shares
+
     return positions
 
 def extract_text_from_image(image_bytes):
@@ -138,33 +153,36 @@ with st.sidebar:
         image_bytes = uploaded_image.read()
         try:
             text_from_image = extract_text_from_image(image_bytes)
-            st.text_area("OCR Result", text_from_image, height=100, key="ocr")
+            with st.expander("OCR Result", expanded=False):
+                st.text_area("Raw text", text_from_image, height=100, key="ocr")
             ocr_positions = parse_positions(text_from_image)
             for t, s in ocr_positions.items():
                 positions[t] = positions.get(t, 0) + s
         except Exception as e:
             st.error(f"OCR failed: {e}")
 
-        total = 0.0
+    total = 0.0
     remove_keys = []
 
     if positions:
         st.markdown("### Portfolio Summary")
-        header = st.columns([2, 2, 2, 1])
+        header = st.columns([2, 2, 2, 2, 1])
         header[0].markdown("**Ticker**")
         header[1].markdown("**Shares**")
-        header[2].markdown("**Total**")
-        header[3].markdown(" ")
+        header[2].markdown("**Price**")
+        header[3].markdown("**Total**")
+        header[4].markdown(" ")
 
         for t, shares in positions.items():
             price, *_ = fetch_stock_info(t)
             value = price * shares if price else 0.0
             total += value
-            row = st.columns([2, 2, 2, 1])
+            row = st.columns([2, 2, 2, 2, 1])
             row[0].write(t)
             row[1].write(shares)
-            row[2].write(f"${value:,.2f}")
-            if row[3].button("Remove", key=f"remove_{t}"):
+            row[2].write(f"${price:,.2f}" if price else "N/A")
+            row[3].write(f"${value:,.2f}")
+            if row[4].button("Remove", key=f"remove_{t}"):
                 remove_keys.append(t)
 
         for rk in remove_keys:


### PR DESCRIPTION
## Summary
- enhance `parse_positions` to better handle messy OCR output
- hide raw OCR text inside an expander
- keep portfolio summary table with price and total columns

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684b365575c88325a1e98af63fc2828c